### PR TITLE
Respect list argument in AdminViewPermissionAdminSite

### DIFF
--- a/admin_view_permission/admin.py
+++ b/admin_view_permission/admin.py
@@ -243,7 +243,7 @@ class AdminViewPermissionAdminSite(admin.AdminSite):
                                   None)
 
         models = model_or_iterable
-        if not isinstance(model_or_iterable, tuple):
+        if not isinstance(model_or_iterable, (tuple, list)):
             models = tuple([model_or_iterable])
 
         if SETTINGS_MODELS or (SETTINGS_MODELS is not None and len(
@@ -264,7 +264,7 @@ class AdminViewPermissionAdminSite(admin.AdminSite):
                     else:
                         admin_class = AdminViewPermissionModelAdmin
 
-                super(AdminViewPermissionAdminSite, self).register(model,
+                super(AdminViewPermissionAdminSite, self).register([model],
                                                                    admin_class,
                                                                    **options)
         else:


### PR DESCRIPTION
I use [django constance](https://github.com/jazzband/django-constance) in my project and I found issue with django admin view permission.

There is piece of code in this project, for registering object in Django Admin, but this object doesn't derived from django.db.models.ModelBase, so it's wrapped in list for compatibility. [One line of code](https://github.com/jazzband/django-constance/blob/master/constance/admin.py#L279)

It works fine with the Django admin, but causes an error in the Django admin view permission.
So I have corrected this bug.

Worth noting that there may be other applications that rely on the behavior of the Django admin, so this fix may be useful for other people.