### PR TITLE
don't display readonly fields when user has add permission

### DIFF
--- a/admin_view_permission/admin.py
+++ b/admin_view_permission/admin.py
@@ -11,9 +11,26 @@ from django.core.urlresolvers import NoReverseMatch, reverse
 from django.utils.encoding import force_text
 from django.utils.text import capfirst
 from django.utils.translation import ugettext as _
+from django.contrib.admin.templatetags.admin_modify import register, submit_row as original_submit_row
+
 
 from .enums import DjangoVersion
 from .utils import django_version
+
+
+@register.inclusion_tag('admin/submit_line.html', takes_context=True)
+def submit_row(context):
+    """submit buttons context change"""
+    ctx = original_submit_row(context)
+    ctx.update({
+        'show_save_and_add_another': context.get('show_save_and_add_another',
+                                                 ctx['show_save_and_add_another']),
+        'show_save_and_continue': context.get('show_save_and_continue',
+                                              ctx['show_save_and_continue']),
+        'show_save': context.get('show_save',
+                                 ctx['show_save'])
+    })
+    return ctx
 
 
 class AdminViewPermissionChangeList(ChangeList):
@@ -222,6 +239,7 @@ class AdminViewPermissionModelAdmin(AdminViewPermissionBaseModelAdmin,
 
             extra_context['show_save'] = False
             extra_context['show_save_and_continue'] = False
+            extra_context['show_save_and_add_another'] = False
 
             inlines = self.get_inline_instances(request, obj)
             for inline in inlines:

--- a/admin_view_permission/admin.py
+++ b/admin_view_permission/admin.py
@@ -80,8 +80,8 @@ class AdminViewPermissionBaseModelAdmin(admin.options.BaseModelAdmin):
         which are in fields attr
         """
         if self.has_view_permission(request, obj) and \
-                ((obj and not self.has_change_permission(request, obj, True)) or \
-                (obj is None and not self.has_add_permission(request))):
+                (obj and not self.has_change_permission(request, obj, True)) \
+                or (obj is None and not self.has_add_permission(request)):
             fields = super(AdminViewPermissionBaseModelAdmin, self).get_fields(
                 request, obj)
             readonly_fields = self.get_readonly_fields(request, obj)
@@ -100,10 +100,9 @@ class AdminViewPermissionBaseModelAdmin(admin.options.BaseModelAdmin):
         readonly_fields = super(AdminViewPermissionBaseModelAdmin,
                                 self).get_readonly_fields(request, obj)
 
-        if (self.has_view_permission(request, obj) and
-                ((obj and not self.has_change_permission(request, obj, True)) or \
-                (obj is None and not self.has_add_permission(request)))):
-
+        if self.has_view_permission(request, obj) and \
+                (obj and not self.has_change_permission(request, obj, True)) \
+                or (obj is None and not self.has_add_permission(request)):
             readonly_fields = (
                 list(readonly_fields) +
                 [field.name for field in self.opts.local_fields

--- a/admin_view_permission/admin.py
+++ b/admin_view_permission/admin.py
@@ -80,7 +80,8 @@ class AdminViewPermissionBaseModelAdmin(admin.options.BaseModelAdmin):
         which are in fields attr
         """
         if self.has_view_permission(request, obj) and \
-                not self.has_change_permission(request, obj, True):
+                ((obj and not self.has_change_permission(request, obj, True)) or \
+                (obj is None and not self.has_add_permission(request))):
             fields = super(AdminViewPermissionBaseModelAdmin, self).get_fields(
                 request, obj)
             readonly_fields = self.get_readonly_fields(request, obj)
@@ -100,7 +101,8 @@ class AdminViewPermissionBaseModelAdmin(admin.options.BaseModelAdmin):
                                 self).get_readonly_fields(request, obj)
 
         if (self.has_view_permission(request, obj) and
-                not self.has_change_permission(request, obj, True)):
+                ((obj and not self.has_change_permission(request, obj, True)) or \
+                (obj is None and not self.has_add_permission(request)))):
 
             readonly_fields = (
                 list(readonly_fields) +


### PR DESCRIPTION
Hello everybody,

thank you for great django app, saved me a lot of work. Unfortunately, I have found a bug when working with view permissions. 

Use case: consider user having view and add permissions for certain model. When using change view, everything works as expected but when you try to add new record, the add form is displayed with readonly fields. 

The root cause is: https://github.com/ctxis/django-admin-view-permission/blob/master/admin_view_permission/admin.py#L83 and https://github.com/ctxis/django-admin-view-permission/blob/master/admin_view_permission/admin.py#L103 . You just check whether user has change permission... Using obj argument we can differ if there is ongoing change/add action.
This PR should solve this issue.
