### PR TITLE
Make sure we never show fields that are excluded

### DIFF
--- a/admin_view_permission/admin.py
+++ b/admin_view_permission/admin.py
@@ -92,6 +92,21 @@ class AdminViewPermissionBaseModelAdmin(admin.options.BaseModelAdmin):
             else:
                 return change_permission
 
+    def get_excluded_fields(self):
+        """ Check if we have no excluded fields defined as we never want to show those (to any user) """
+        if self.exclude is None:
+            exclude = []
+        else:
+            exclude = list(self.exclude)
+
+        # logic taken from: django.contrib.admin.options.ModelAdmin#get_form
+        if self.exclude is None and hasattr(self.form, '_meta') and self.form._meta.exclude:
+            # Take the custom ModelForm's Meta.exclude into account only if the
+            # ModelAdmin doesn't define its own.
+            exclude.extend(self.form._meta.exclude)
+
+        return exclude
+
     def get_fields(self, request, obj=None):
         """
         If the user has only the view permission return these readonly fields
@@ -102,8 +117,9 @@ class AdminViewPermissionBaseModelAdmin(admin.options.BaseModelAdmin):
                 obj is None and not self.has_add_permission(request))):
             fields = super(AdminViewPermissionBaseModelAdmin, self).get_fields(
                 request, obj)
+            excluded_fields = self.get_excluded_fields()
             readonly_fields = self.get_readonly_fields(request, obj)
-            new_fields = [i for i in fields if i in readonly_fields]
+            new_fields = [i for i in fields if i in readonly_fields and i not in excluded_fields]
             return new_fields
         else:
             return super(AdminViewPermissionBaseModelAdmin, self).get_fields(

--- a/admin_view_permission/admin.py
+++ b/admin_view_permission/admin.py
@@ -93,16 +93,20 @@ class AdminViewPermissionBaseModelAdmin(admin.options.BaseModelAdmin):
                 return change_permission
 
     def get_excluded_fields(self):
-        """ Check if we have no excluded fields defined as we never want to show those (to any user) """
+        """
+        Check if we have no excluded fields defined as we never want to
+        show those (to any user)
+        """
         if self.exclude is None:
             exclude = []
         else:
             exclude = list(self.exclude)
 
         # logic taken from: django.contrib.admin.options.ModelAdmin#get_form
-        if self.exclude is None and hasattr(self.form, '_meta') and self.form._meta.exclude:
-            # Take the custom ModelForm's Meta.exclude into account only if the
-            # ModelAdmin doesn't define its own.
+        if self.exclude is None and hasattr(
+                self.form, '_meta') and self.form._meta.exclude:
+            # Take the custom ModelForm's Meta.exclude into account only
+            # if the ModelAdmin doesn't define its own.
             exclude.extend(self.form._meta.exclude)
 
         return exclude
@@ -115,11 +119,14 @@ class AdminViewPermissionBaseModelAdmin(admin.options.BaseModelAdmin):
         if ((self.has_view_permission(request, obj) and (
             obj and not self.has_change_permission(request, obj, True))) or (
                 obj is None and not self.has_add_permission(request))):
-            fields = super(AdminViewPermissionBaseModelAdmin, self).get_fields(
-                request, obj)
+            fields = super(
+                AdminViewPermissionBaseModelAdmin,
+                self).get_fields(request, obj)
             excluded_fields = self.get_excluded_fields()
             readonly_fields = self.get_readonly_fields(request, obj)
-            new_fields = [i for i in fields if i in readonly_fields and i not in excluded_fields]
+            new_fields = [i for i in fields if
+                          i in readonly_fields and
+                          i not in excluded_fields]
             return new_fields
         else:
             return super(AdminViewPermissionBaseModelAdmin, self).get_fields(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -9,8 +9,8 @@ from .test_app.admin import (
     InlineModelAdmin1,
     InlineModelAdmin2,
     ModelAdmin1,
-    ModelAdmin2,
     ModelAdmin1WithFormExclude,
+    ModelAdmin2,
 )
 from .test_app.models import (
     TestModel0,
@@ -113,7 +113,8 @@ class AdminViewPermissionTestCase(BaseTestCase):
         # TestModel1 to have as a ModelAdmin the ModelAdmin1 via the
         # assigned_modeladmin attr. In the other tests we have to change them)
         self.modeladmin_testmodel1 = ModelAdmin1(TestModel1, admin.site)
-        self.modeladmin_testmodel1_with_form_exclude = ModelAdmin1WithFormExclude(TestModel1, admin.site)
+        self.modeladmin_testmodel1_with_form_exclude = \
+            ModelAdmin1WithFormExclude(TestModel1, admin.site)
         self.modeladmin_testmodel5 = ModelAdmin1(TestModel5, admin.site)
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -10,6 +10,7 @@ from .test_app.admin import (
     InlineModelAdmin2,
     ModelAdmin1,
     ModelAdmin2,
+    ModelAdmin1WithFormExclude,
 )
 from .test_app.models import (
     TestModel0,
@@ -112,6 +113,7 @@ class AdminViewPermissionTestCase(BaseTestCase):
         # TestModel1 to have as a ModelAdmin the ModelAdmin1 via the
         # assigned_modeladmin attr. In the other tests we have to change them)
         self.modeladmin_testmodel1 = ModelAdmin1(TestModel1, admin.site)
+        self.modeladmin_testmodel1_with_form_exclude = ModelAdmin1WithFormExclude(TestModel1, admin.site)
         self.modeladmin_testmodel5 = ModelAdmin1(TestModel5, admin.site)
 
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import pytest
 from django.contrib import admin
 from django.core.exceptions import FieldError
-from django.forms import ModelForm
 from django.test import SimpleTestCase, override_settings
 
 from admin_view_permission.admin import (
@@ -277,7 +276,8 @@ class TestAdminViewPermissionBaseModelAdmin(AdminViewPermissionTestCase):
 
     def test_get_fields_excluded_model_form_and_admin_exclude_super_user(self):
         super_user = self.create_super_user()
-        # should override the form exclude when explicitly set on the admin exclude
+        # should override the form exclude when explicitly set on the
+        # admin exclude
         self.modeladmin_testmodel1_with_form_exclude.exclude = ['var3']
         fields = self.modeladmin_testmodel1_with_form_exclude.get_fields(
             self.django_request(super_user), self.object_testmodel1)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import pytest
 from django.contrib import admin
 from django.core.exceptions import FieldError
+from django.forms import ModelForm
 from django.test import SimpleTestCase, override_settings
 
 from admin_view_permission.admin import (
@@ -229,6 +230,58 @@ class TestAdminViewPermissionBaseModelAdmin(AdminViewPermissionTestCase):
             self.django_request(super_user), self.object_testmodel1)
 
         assert fields == ['var1', 'var2', 'var3', 'var4']
+
+    # test excluded fields
+    def test_get_fields_excluded_simple_user_1(self):
+        # View permission only
+        simple_user = self.create_simple_user()
+        simple_user.user_permissions.add(self.view_permission_testmodel1)
+        self.modeladmin_testmodel1.exclude = ['var4']
+        fields = self.modeladmin_testmodel1.get_fields(
+            self.django_request(simple_user))
+
+        assert fields == ['var1', 'var2', 'var3']
+
+    def test_get_fields_excluded_simple_user_2(self):
+        # View permission only
+        simple_user = self.create_simple_user()
+        simple_user.user_permissions.add(self.view_permission_testmodel1)
+        self.modeladmin_testmodel1.exclude = ['var4']
+        fields = self.modeladmin_testmodel1.get_fields(
+            self.django_request(simple_user), self.object_testmodel1)
+
+        assert fields == ['var1', 'var2', 'var3']
+
+    def test_get_fields_excluded_super_user_1(self):
+        super_user = self.create_super_user()
+        self.modeladmin_testmodel1.exclude = ['var4']
+        fields = self.modeladmin_testmodel1.get_fields(
+            self.django_request(super_user))
+
+        assert fields == ['var1', 'var2', 'var3']
+
+    def test_get_fields_excluded_super_user_2(self):
+        super_user = self.create_super_user()
+        self.modeladmin_testmodel1.exclude = ['var4']
+        fields = self.modeladmin_testmodel1.get_fields(
+            self.django_request(super_user), self.object_testmodel1)
+
+        assert fields == ['var1', 'var2', 'var3']
+
+    def test_get_fields_excluded_model_form_super_user(self):
+        super_user = self.create_super_user()
+        fields = self.modeladmin_testmodel1_with_form_exclude.get_fields(
+            self.django_request(super_user), self.object_testmodel1)
+
+        assert fields == ['var1', 'var2', 'var3']
+
+    def test_get_fields_excluded_model_form_and_admin_exclude_super_user(self):
+        super_user = self.create_super_user()
+        # should override the form exclude when explicitly set on the admin exclude
+        self.modeladmin_testmodel1_with_form_exclude.exclude = ['var3']
+        fields = self.modeladmin_testmodel1_with_form_exclude.get_fields(
+            self.django_request(super_user), self.object_testmodel1)
+        assert fields == ['var1', 'var2', 'var4']
 
     # get_actions
 

--- a/tests/test_app/admin.py
+++ b/tests/test_app/admin.py
@@ -64,4 +64,5 @@ class TestModel1Form(forms.ModelForm):
 class ModelAdmin1WithFormExclude(view_admin.AdminViewPermissionModelAdmin):
     form = TestModel1Form
 
+
 admin.site.register(TestModel1, DefaultModelAdmin)

--- a/tests/test_app/admin.py
+++ b/tests/test_app/admin.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+from django import forms
 from django.contrib import admin
 
 from admin_view_permission import admin as view_admin
@@ -53,5 +54,14 @@ class ModelAdmin2(view_admin.AdminViewPermissionModelAdmin):
         InlineModelAdmin2
     ]
 
+
+class TestModel1Form(forms.ModelForm):
+    class Meta:
+        model = TestModel1
+        exclude = ['var4']
+
+
+class ModelAdmin1WithFormExclude(view_admin.AdminViewPermissionModelAdmin):
+    form = TestModel1Form
 
 admin.site.register(TestModel1, DefaultModelAdmin)


### PR DESCRIPTION
Currently when a model specifies fields that should be excluded they are shown for users with only the view permission. 

```python
class MyModelAdmin(admin.ModelAdmin):
    exclude = ['super', 'secret', 'fields']  # <-- these are now shown!!
```

I think this is never what someone would want...

This PR fixes that.