### PR TITLE
Add django-parler compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,8 @@ Support
 * Django: 1.8, 1.9, 1.10, 1.11, 2.0
 * Python: 2.7, 3.4, 3.5, 3.6
 
+Compatible with `django-parler <https://django-parler.readthedocs.io/>`_'s translatable models. To verify which django-parler version our test suite runs against, check ``requirements-debug.txt``. You do not need django-parler to install django-admin-view-permission.
+
 Documentation
 -------------
 For a full documentation you can visit: http://django-admin-view-permission.readthedocs.org/

--- a/admin_view_permission/admin.py
+++ b/admin_view_permission/admin.py
@@ -6,9 +6,9 @@ from django.apps import apps
 from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin.options import TO_FIELD_VAR
+from django.contrib.admin.templatetags.admin_modify import register
 from django.contrib.admin.templatetags.admin_modify import \
     submit_row as original_submit_row
-from django.contrib.admin.templatetags.admin_modify import register
 from django.contrib.admin.utils import flatten, unquote
 from django.contrib.admin.views.main import ChangeList
 from django.contrib.auth import get_permission_codename

--- a/admin_view_permission/admin.py
+++ b/admin_view_permission/admin.py
@@ -191,6 +191,13 @@ class AdminViewPermissionBaseModelAdmin(admin.options.BaseModelAdmin):
                     f for f in readonly_fields if f not in excluded_fields
                 ]
 
+            # django-parler compatibility: if this model is translatable,
+            # ensure its fields are set to readonly too.
+            if hasattr(self.model, '_parler_meta'):
+                readonly_fields += list(
+                    self.model._parler_meta._fields_to_model.keys()
+                )
+
         return tuple(readonly_fields)
 
     def get_actions(self, request):

--- a/admin_view_permission/apps.py
+++ b/admin_view_permission/apps.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
-from django.apps import apps as global_apps
 from django.apps import AppConfig
+from django.apps import apps as global_apps
 from django.conf import settings
 from django.contrib import admin
 from django.db.models.signals import post_migrate

--- a/requirements-debug.txt
+++ b/requirements-debug.txt
@@ -17,3 +17,9 @@ mock
 # Docs
 sphinx
 sphinx-autobuild
+
+# To test django-parler compatibility
+django-parler==1.9.1
+
+# To parse HTML in tests
+beautifulsoup4==4.6.0

--- a/tests/test_app/admin.py
+++ b/tests/test_app/admin.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from django.contrib import admin
+from parler.admin import TranslatableAdmin
 
 from admin_view_permission import admin as view_admin
 
@@ -24,6 +25,13 @@ class DefaultModelAdmin(admin.ModelAdmin):
 
 
 admin.site.register(TestModel1, DefaultModelAdmin)
+
+
+class TestModelParlerAdmin(TranslatableAdmin, admin.ModelAdmin):
+    model = TestModelParler
+
+
+admin.site.register(TestModelParler, TestModelParlerAdmin)
 
 
 # Modeladmin for testing

--- a/tests/test_app/models.py
+++ b/tests/test_app/models.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from django.db import models
+from parler.models import TranslatableModel, TranslatedFields
 
 
 class TestModel0(models.Model):
@@ -58,3 +59,18 @@ class TestModel6(models.Model):
     var2 = models.CharField(max_length=200)
     var3 = models.TextField()
     var4 = models.IntegerField()
+
+
+class TestModelParler(TranslatableModel):
+    var1 = models.CharField(max_length=200)
+    var2 = models.TextField()
+    var3 = models.IntegerField()
+
+    translations = TranslatedFields(
+        var4=models.CharField(max_length=20),
+        var5=models.TextField(),
+    )
+
+    @property
+    def var6(self):
+        return 'readonly_field'

--- a/tests/tests/functional/test_views.py
+++ b/tests/tests/functional/test_views.py
@@ -1,5 +1,9 @@
 from __future__ import unicode_literals
 
+from bs4 import BeautifulSoup
+from django import VERSION
+from django.conf import settings
+from django.test import override_settings
 from model_mommy import mommy
 
 from tests.tests.helpers import AdminViewPermissionViewsTestCase
@@ -162,6 +166,41 @@ class TestModelAdminViews(AdminViewPermissionViewsTestCase):
         )
 
         assert response.status_code == 200
+
+    def test_change_view_from_simple_user_translatable(self):
+        """
+        Smoke test: check if the change view renders for a django-parler model.
+        """
+        # Ensure parler's templates are registered through INSTALLED_APPS,
+        # but only for this test. This mimics the install steps at
+        # http://django-parler.readthedocs.io/en/latest/quickstart.html.
+        current_installed_apps = settings.INSTALLED_APPS
+        installed_apps_with_parler = current_installed_apps + ['parler']
+
+        with override_settings(INSTALLED_APPS=installed_apps_with_parler):
+            obj = mommy.make('test_app.TestModelParler')
+            self.client.login(
+                username='user_with_v_perm_on_model1parler',
+                password='simple_user',
+            )
+            response = self.client.get(
+                reverse(
+                    'admin:%s_%s_change' % (
+                        'test_app', 'testmodelparler'
+                    ),
+                    args=(obj.pk,)
+                ),
+            )
+            assert response.status_code == 200
+
+            # var4 is a translatable field on this model. Check that it is
+            # marked as read only under Django versions supporting it.
+            if VERSION[0:2] == (1, 11) or VERSION[0] == 2:
+                bs = BeautifulSoup(response.content.decode('utf-8'),
+                                   'html.parser')
+                var4_tags = bs.select('.field-var4')
+                assert len(var4_tags) == 1
+                assert len(var4_tags[0].select('.readonly')) == 1
 
     def test_change_view_from_simple_user_unauthorized_post(self):
         obj = mommy.make('test_app.TestModel1')

--- a/tests/tests/helpers.py
+++ b/tests/tests/helpers.py
@@ -63,6 +63,13 @@ class DataMixin(object):
         cls.delete_permission_model1 = Permission.objects.get(
             name='Can delete test model1')
 
+        cls.view_permission_model1parler = Permission.objects.get(
+            name='Can view testmodelparler'
+        )
+        cls.view_permission_model1parlertranslation = Permission.objects.get(
+            name='Can view testmodelparlertranslation'
+        )
+
         cls.add_permission_model4 = Permission.objects.get(
             name='Can add test model4')
         cls.view_permission_model4 = Permission.objects.get(
@@ -110,6 +117,16 @@ class AdminViewPermissionViewsTestCase(DataMixin, TestCase):
         cls.user_with_vd_perm_on_moedl1.user_permissions.add(
             cls.view_permission_model1,
             cls.delete_permission_model1,
+        )
+
+        cls.user_with_v_perm_on_model1parler = create_simple_user(
+            username='user_with_v_perm_on_model1parler'
+        )
+        cls.user_with_v_perm_on_model1parler.user_permissions.add(
+            cls.view_permission_model1parler,
+        )
+        cls.user_with_v_perm_on_model1parler.user_permissions.add(
+            cls.view_permission_model1parlertranslation,
         )
 
         cls.super_user = create_super_user(username='super_user')


### PR DESCRIPTION
We use django-parler in our admin to localize content to three different languages, and django-parler fields weren't showing up as readonly for people with the view permission. This fixes that.

django-admin-view-permission should still be able to function without having django-parler installed. But for those that use it, this makes them compatible.