### PR TITLE
Auth User password help-text bug fixed

### DIFF
--- a/admin_view_permission/admin.py
+++ b/admin_view_permission/admin.py
@@ -327,19 +327,21 @@ class AdminViewPermissionUserAdmin(AdminViewPermissionModelAdmin):
         form = super(AdminViewPermissionUserAdmin, self).get_form(
             request, obj, **kwargs)
 
+        if 'password' in form.base_fields:
+            password_field = form.base_fields['password']
+        elif 'password2' in form.base_fields:
+            password_field = form.base_fields['password2']
+        else:
+            password_field = None
+
         # TODO: I don't like this at all. Find another way to change the
         # TODO: help_text
         if not self._has_change_only_permission(request):
-            form.base_fields['password'].help_text = _(
+            password_field.help_text = _(
                 "Raw passwords are not stored, so there is no way to see this "
                 "user's password."
             )
         else:
-            if 'password' in form.base_fields:
-                password_field = form.base_fields['password']
-            elif 'password2' in form.base_fields:
-                password_field = form.base_fields['password2']
-
             if password_field:
                 password_field.help_text = _(
                     "Raw passwords are not stored, so there is no way to see this "

--- a/admin_view_permission/admin.py
+++ b/admin_view_permission/admin.py
@@ -335,7 +335,7 @@ class AdminViewPermissionUserAdmin(AdminViewPermissionModelAdmin):
                 "user's password."
             )
         else:
-            form.base_fields['password'].help_text = _(
+            form.base_fields['password2'].help_text = _(
                 "Raw passwords are not stored, so there is no way to see this "
                 "user's password, but you can change the password using "
                 "<a href=\"../password/\">this form</a>."

--- a/admin_view_permission/admin.py
+++ b/admin_view_permission/admin.py
@@ -335,11 +335,17 @@ class AdminViewPermissionUserAdmin(AdminViewPermissionModelAdmin):
                 "user's password."
             )
         else:
-            form.base_fields['password2'].help_text = _(
-                "Raw passwords are not stored, so there is no way to see this "
-                "user's password, but you can change the password using "
-                "<a href=\"../password/\">this form</a>."
-            )
+            if 'password' in form.base_fields:
+                password_field = form.base_fields['password']
+            elif 'password2' in form.base_fields:
+                password_field = form.base_fields['password2']
+
+            if password_field:
+                password_field.help_text = _(
+                    "Raw passwords are not stored, so there is no way to see this "
+                    "user's password, but you can change the password using "
+                    "<a href=\"../password/\">this form</a>."
+                )
 
         return form
 


### PR DESCRIPTION
The bug was that when adding a new User in django admin panel, an exception was thrown because of wrong reference of password field.