### PR TITLE
Add a setting to exclude models

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,16 +49,34 @@ and finally run ``python manage.py migrate``.
 Configuration
 -------------
 
-This app provides a setting::
+ADMIN_VIEW_PERMISSION_MODELS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This setting defines which models you want to be added the view permission. If
+you don't specify this setting then the view permission will be applied to all
+the models.
+
+::
 
     ADMIN_VIEW_PERMISSION_MODELS = [
         'auth.User',
         ...
     ]
 
-in which you can provide which models you want to be added the view permission.
-If you don't specify this setting then the view permission will be applied to
-all the models.
+
+
+ADMIN_VIEW_PERMISSION_MODELS_EXCLUDE
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This setting defines which models you don't want to be added the view
+permission.
+
+::
+
+     ADMIN_VIEW_PERMISSION_MODELS_EXCLUDE = [
+         'auth.User',
+         ...
+     ]
 
 Uninstall
 ---------

--- a/admin_view_permission/admin.py
+++ b/admin_view_permission/admin.py
@@ -332,8 +332,6 @@ class AdminViewPermissionUserAdmin(AdminViewPermissionModelAdmin):
         password_field = None
         if 'password' in form.base_fields:
             password_field = form.base_fields['password']
-        elif 'password2' in form.base_fields:
-            password_field = form.base_fields['password2']
         if password_field:
             if not self._has_change_only_permission(request):
                 password_field.help_text = _(

--- a/admin_view_permission/admin.py
+++ b/admin_view_permission/admin.py
@@ -389,8 +389,6 @@ class AdminViewPermissionAdminSite(admin.AdminSite):
         is_user_model = settings.AUTH_USER_MODEL in [
             get_model_name(i) for i in models]
         is_all = SETTINGS_MODELS is None
-        is_empty_models = SETTINGS_MODELS is not None and len(
-            SETTINGS_MODELS) == 0
 
         for model in models:
             model_name = get_model_name(model)

--- a/admin_view_permission/admin.py
+++ b/admin_view_permission/admin.py
@@ -329,17 +329,23 @@ class AdminViewPermissionUserAdmin(AdminViewPermissionModelAdmin):
 
         # TODO: I don't like this at all. Find another way to change the
         # TODO: help_text
-        if not self._has_change_only_permission(request):
-            form.base_fields['password'].help_text = _(
-                "Raw passwords are not stored, so there is no way to see this "
-                "user's password."
-            )
-        else:
-            form.base_fields['password'].help_text = _(
-                "Raw passwords are not stored, so there is no way to see this "
-                "user's password, but you can change the password using "
-                "<a href=\"../password/\">this form</a>."
-            )
+        password_field = None
+        if 'password' in form.base_fields:
+            password_field = form.base_fields['password']
+        elif 'password2' in form.base_fields:
+            password_field = form.base_fields['password2']
+        if password_field:
+            if not self._has_change_only_permission(request):
+                password_field.help_text = _(
+                    "Raw passwords are not stored, so there is no way to see "
+                    "this user's password."
+                )
+            else:
+                password_field.help_text = _(
+                    "Raw passwords are not stored, so there is no way to see "
+                    "this user's password, but you can change the password "
+                    "using <a href=\"../password/\">this form</a>."
+                )
 
         return form
 

--- a/admin_view_permission/admin.py
+++ b/admin_view_permission/admin.py
@@ -379,6 +379,8 @@ class AdminViewPermissionAdminSite(admin.AdminSite):
         """
         SETTINGS_MODELS = getattr(
             settings, 'ADMIN_VIEW_PERMISSION_MODELS', None)
+        SETTINGS_MODELS_EXCLUDE = getattr(
+            settings, 'ADMIN_VIEW_PERMISSION_MODELS_EXCLUDE', None) or []
 
         models = model_or_iterable
         if not isinstance(model_or_iterable, (tuple, list)):
@@ -386,21 +388,18 @@ class AdminViewPermissionAdminSite(admin.AdminSite):
 
         is_user_model = settings.AUTH_USER_MODEL in [
             get_model_name(i) for i in models]
+        is_all = SETTINGS_MODELS is None
+        is_empty_models = SETTINGS_MODELS is not None and len(
+            SETTINGS_MODELS) == 0
 
-        if SETTINGS_MODELS or (SETTINGS_MODELS is not None and len(
-                SETTINGS_MODELS) == 0):
-            for model in models:
-                model_name = get_model_name(model)
-                if model_name in SETTINGS_MODELS:
-                    admin_class = self._get_admin_class(
-                        admin_class, is_user_model)
+        for model in models:
+            model_name = get_model_name(model)
+            if (is_all or model_name in SETTINGS_MODELS) and \
+                    model_name not in SETTINGS_MODELS_EXCLUDE:
+                admin_class = self._get_admin_class(admin_class, is_user_model)
 
-                super(AdminViewPermissionAdminSite, self).register(
-                    [model], admin_class, **options)
-        else:
-            admin_class = self._get_admin_class(admin_class, is_user_model)
             super(AdminViewPermissionAdminSite, self).register(
-                model_or_iterable, admin_class, **options)
+                [model], admin_class, **options)
 
     def _build_app_dict(self, request, label=None):
         """

--- a/admin_view_permission/apps.py
+++ b/admin_view_permission/apps.py
@@ -13,14 +13,18 @@ from .utils import get_model_name
 def update_permissions(sender, app_config, verbosity, apps=global_apps,
                        **kwargs):
     settings_models = getattr(settings, 'ADMIN_VIEW_PERMISSION_MODELS', None)
+    settings_models_exclude = \
+        getattr(settings, 'ADMIN_VIEW_PERMISSION_MODELS_EXCLUDE', None) or []
+    is_empty_models = settings_models is not None and len(settings_models) == 0
 
     # TODO: Maybe look at the registry not in all models
     for app in apps.get_app_configs():
         for model in app.get_models():
+            model_name = get_model_name(model)
+            if model_name in settings_models_exclude:
+                continue
             view_permission = 'view_%s' % model._meta.model_name
-            if settings_models or (settings_models is not None and len(
-                    settings_models) == 0):
-                model_name = get_model_name(model)
+            if settings_models or is_empty_models:
                 if model_name in settings_models and view_permission not in \
                         [perm[0] for perm in model._meta.permissions]:
                     model._meta.permissions += (

--- a/admin_view_permission/utils.py
+++ b/admin_view_permission/utils.py
@@ -20,10 +20,12 @@ def django_version():
 
 
 def get_model_name(model):
-    if django_version() == DjangoVersion.DJANGO_18:
+    try:
+        if django_version() == DjangoVersion.DJANGO_18:
+            raise AttributeError
+        return model._meta.label
+    except AttributeError:
         return '%s.%s' % (model._meta.app_label, model._meta.object_name)
-
-    return model._meta.label
 
 
 def get_all_permissions(opts, ctype=None):

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,8 +1,8 @@
 Configuration
 =============
 
-The admin view permission provides one setting that you can add in your project's
-settings module to customize its behavior.
+The admin view permission provides two settings that you can add in your
+project's settings module to customize its behavior.
 
 ADMIN_VIEW_PERMISSION_MODELS
 ----------------------------
@@ -16,6 +16,21 @@ Example
 ::
 
      ADMIN_VIEW_PERMISSION_MODELS = [
+         'auth.User',
+         ...
+     ]
+
+ADMIN_VIEW_PERMISSION_MODELS_EXCLUDE
+----------------------------
+
+This setting defines which models you don't want to be added the view
+permission.
+
+Example
+~~~~~~~
+::
+
+     ADMIN_VIEW_PERMISSION_MODELS_EXCLUDE = [
          'auth.User',
          ...
      ]

--- a/tests/tests/unit/test_admin.py
+++ b/tests/tests/unit/test_admin.py
@@ -1718,7 +1718,7 @@ class TestAdminViewPermissionUserAdmin(TestCase):
         admin_site.register(get_user_model(), UserAdmin)
         self.view = admin_site._registry[get_user_model()]
         self.url = lambda pk: \
-            reverse('admin:auth_user_password_change', kwargs={'id': pk})
+            reverse('admin:auth_user_password_change', args=(pk,))
 
     def test_user_change_password(self):
         simple_user = create_simple_user('simple_user')

--- a/tests/tests/unit/test_admin.py
+++ b/tests/tests/unit/test_admin.py
@@ -1753,3 +1753,30 @@ class TestAdminViewPermissionAdminSite(SimpleTestCase):
         self.admin_site.register(TestModel1)
         assert not isinstance(self.admin_site._registry[TestModel1],
                               AdminViewPermissionModelAdmin)
+
+    @override_settings(ADMIN_VIEW_PERMISSION_MODELS_EXCLUDE=[
+        'test_app.TestModel1'
+    ])
+    def test_register__7(self):
+        self.admin_site.register(TestModel1)
+        modeladmin5 = type(str('TestModelAdmin5'), (admin.ModelAdmin,), {})
+        self.admin_site.register(TestModel5, modeladmin5)
+        assert not isinstance(self.admin_site._registry[TestModel1],
+                              AdminViewPermissionModelAdmin)
+        assert isinstance(self.admin_site._registry[TestModel5],
+                          AdminViewPermissionModelAdmin)
+        assert isinstance(self.admin_site._registry[TestModel5],
+                          modeladmin5)
+
+    @override_settings(ADMIN_VIEW_PERMISSION_MODELS_EXCLUDE=[])
+    def test_register__8(self):
+        self.admin_site.register(TestModel1)
+        modeladmin5 = type(str('TestModelAdmin5'), (admin.ModelAdmin,), {})
+        self.admin_site.register(TestModel5)
+        assert isinstance(self.admin_site._registry[TestModel1],
+                          AdminViewPermissionModelAdmin)
+        assert isinstance(self.admin_site._registry[TestModel5],
+                          AdminViewPermissionModelAdmin)
+        assert isinstance(self.admin_site._registry[TestModel5],
+                          modeladmin5)
+

--- a/tests/tests/unit/test_admin.py
+++ b/tests/tests/unit/test_admin.py
@@ -1772,7 +1772,7 @@ class TestAdminViewPermissionAdminSite(SimpleTestCase):
     def test_register__8(self):
         self.admin_site.register(TestModel1)
         modeladmin5 = type(str('TestModelAdmin5'), (admin.ModelAdmin,), {})
-        self.admin_site.register(TestModel5)
+        self.admin_site.register(TestModel5, modeladmin5)
         assert isinstance(self.admin_site._registry[TestModel1],
                           AdminViewPermissionModelAdmin)
         assert isinstance(self.admin_site._registry[TestModel5],

--- a/tests/tests/unit/test_admin.py
+++ b/tests/tests/unit/test_admin.py
@@ -1779,4 +1779,3 @@ class TestAdminViewPermissionAdminSite(SimpleTestCase):
                           AdminViewPermissionModelAdmin)
         assert isinstance(self.admin_site._registry[TestModel5],
                           modeladmin5)
-

--- a/tests/tests/unit/test_apps.py
+++ b/tests/tests/unit/test_apps.py
@@ -91,3 +91,16 @@ class TestAdminViewPermissionConfig(TestCase):
             self.model3._meta.permissions,
             ((u'copy_apptestmodel3', u'Can copy apptestmodel3'), )
         )
+
+    @override_settings(
+        ADMIN_VIEW_PERMISSION_MODELS=None,
+        ADMIN_VIEW_PERMISSION_MODELS_EXCLUDE=['test_app.AppTestModel2'],
+    )
+    def test_ready__with_exclude(self):
+        self._trigger_signal()
+        self.assertEqual(self.model1._meta.permissions,
+                         [('view_apptestmodel1', 'Can view apptestmodel1'), ])
+        self.assertEqual(self.model2._meta.permissions, [])
+        self.assertEqual(self.model3._meta.permissions,
+                         ((u'copy_apptestmodel3', u'Can copy apptestmodel3'),
+                          (u'view_apptestmodel3', u'Can view apptestmodel3')))


### PR DESCRIPTION
Hello and thanks for the repo! 

This PR provides a possibility to exclude a view permission for some models. 

For example, if you want to add a view permission for all models, but only not for a user model, you can do this:

```
ADMIN_VIEW_PERMISSION_MODELS = None
ADMIN_VIEW_PERMISSION_MODELS_EXCLUDE = ['auth.User']
```

Also I fixed the `utils.get_model_name` function for models which don't have a `_meta.label` attribute. An example of this problem: https://github.com/jazzband/django-constance/pull/257#issue-171543294